### PR TITLE
Added support for generic methods.

### DIFF
--- a/ApiCheck.Test/Builder/ApiMethodBuilder.cs
+++ b/ApiCheck.Test/Builder/ApiMethodBuilder.cs
@@ -13,6 +13,7 @@ namespace ApiCheck.Test.Builder
     private MethodAttributes _methodAttributes;
     private Type _returnType;
     private readonly IList<ApiParameter> _parameters = new List<ApiParameter>();
+    private readonly ISet<string> _genericParameters = new HashSet<string>();
     private bool _ctor;
 
     private ApiMethodBuilder()
@@ -63,6 +64,12 @@ namespace ApiCheck.Test.Builder
       return this;
     }
 
+    public ApiMethodBuilder GenericParameter(string name = "T")
+    {
+      _genericParameters.Add(name);
+      return this;
+    }
+
     public ApiTypeBuilder Build()
     {
       if (_ctor)
@@ -76,6 +83,7 @@ namespace ApiCheck.Test.Builder
       {
         MethodBuilder methodBuilder = _parent.TypeBuilder.DefineMethod(_name, _methodAttributes, _returnType, _parameters.Select(parameter => parameter.Type).ToArray());
         DefineParameters(methodBuilder.DefineParameter);
+        DefineGenericParameters(methodBuilder.DefineGenericParameters);
         ILGenerator ilGenerator = methodBuilder.GetILGenerator();
         ilGenerator.Emit(ApiBuilderHelper.GetReturnOpCodeByType(_returnType));
         ilGenerator.Emit(OpCodes.Ret);
@@ -92,6 +100,14 @@ namespace ApiCheck.Test.Builder
         {
           parameterBuilder.SetConstant(parameter.DefaultValue);
         }
+      }
+    }
+
+    private void DefineGenericParameters(Func<string[], GenericTypeParameterBuilder[]> defineGenericParameter)
+    {
+      if (_genericParameters.Any())
+      {
+        defineGenericParameter(_genericParameters.ToArray());
       }
     }
 

--- a/ApiCheck.Test/Comparer/ComparerContextTest.cs
+++ b/ApiCheck.Test/Comparer/ComparerContextTest.cs
@@ -32,6 +32,17 @@ namespace ApiCheck.Test.Comparer
     }
 
     [Test]
+    public void When_generic_method_is_changed_and_ignored_should_not_report()
+    {
+      Assembly assembly1 = ApiBuilder.CreateApi("A").Class("A.C").Method("M").Build().Method("M").GenericParameter().Build().Build().Build();
+      Assembly assembly2 = ApiBuilder.CreateApi("A").Class("A.C").Method("M2").Build().Method("M2").GenericParameter().Build().Build().Build();
+      IComparerResult sut = new Builder(assembly1, assembly2, new[] { "A.C.M" }).Build();
+
+      Assert.AreEqual(0, sut.ComparerResults.First().RemovedItems.Count());
+      Assert.AreEqual(2, sut.ComparerResults.First().AddedItems.Count());
+    }
+
+    [Test]
     public void When_ctor_is_changed_and_ignored_should_not_report()
     {
       Assembly assembly1 = ApiBuilder.CreateApi("A").Class("A.C").Constructor().Parameter(typeof(int)).Build().Build().Build();

--- a/ApiCheck/ApiCheck.csproj
+++ b/ApiCheck/ApiCheck.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ApiCheck</RootNamespace>
     <AssemblyName>ApiCheck</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -61,6 +62,7 @@
     <Compile Include="Comparer\Item.cs" />
     <Compile Include="Comparer\MethodComparer.cs" />
     <Compile Include="Comparer\MethodComparerBase.cs" />
+    <Compile Include="Comparer\MethodItem.cs" />
     <Compile Include="Comparer\PairList.cs" />
     <Compile Include="Comparer\ParameterComparer.cs" />
     <Compile Include="Comparer\PropertyComparer.cs" />

--- a/ApiCheck/ApiCheck.csproj
+++ b/ApiCheck/ApiCheck.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,11 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ApiCheck</RootNamespace>
     <AssemblyName>ApiCheck</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/ApiCheck/Comparer/Item.cs
+++ b/ApiCheck/Comparer/Item.cs
@@ -42,7 +42,7 @@ namespace ApiCheck.Comparer
       {
         return true;
       }
-      if (obj.GetType() != typeof(Item))
+      if (!(obj is Item))
       {
         return false;
       }

--- a/ApiCheck/Comparer/MethodItem.cs
+++ b/ApiCheck/Comparer/MethodItem.cs
@@ -1,0 +1,59 @@
+﻿using ApiCheck.Utility;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ApiCheck.Comparer
+{
+  internal class MethodItem : Item
+  {
+    private readonly string[] _genericStrings;
+    private readonly MethodBase _method;
+
+    public MethodItem(MethodBase method)
+      : base(method.Name, method.GetParameters().Select(param => param.ParameterType).ToArray())
+    {
+      _method = method;
+
+      Type[] genericTypes = method.IsGenericMethod ? method.GetGenericArguments() : new Type[0];
+
+      _genericStrings = genericTypes.Select(genericType => genericType.GetCompareableName()).ToArray();
+    }
+
+    public MethodBase Method
+    {
+      get { return _method; }
+    }
+
+    private bool Equals(MethodItem other)
+    {
+      return _genericStrings.SequenceEqual(other._genericStrings);
+    }
+
+    public override bool Equals(object obj)
+    {
+      if (!base.Equals(obj))
+      {
+        return false;
+      }
+      if (!(obj is MethodItem))
+      {
+        return false;
+      }
+      return Equals((MethodItem)obj);
+    }
+
+    public override int GetHashCode()
+    {
+      unchecked
+      {
+        int hashCode = base.GetHashCode();
+        foreach (string genericString in _genericStrings)
+        {
+          hashCode = (hashCode * 231) ^ genericString.GetHashCode();
+        }
+        return hashCode;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently ApiCheck ignores generic method arguments and fails on generic method overloads. For example the following type definition would cause an exception on [PairList.AddNewItem:28](https://github.com/PMudra/ApiCheck/blob/master/ApiCheck/Comparer/PairList.cs#L28). This pull request solves this scenario by taking generic method arguments into account.

```
public class Foo
{
  public void Bar() {}
  public void Bar<T>() {}
}
```
```
SanityChecks.Api.ApiBackwardsCompatibilityTest.ApiContainsNoBackwardsIncompatibleChanges threw exception: 
System.InvalidOperationException: Sequence contains more than one matching element
    at System.Linq.Enumerable.SingleOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at ApiCheck.Comparer.PairList`1.AddNewItem(T newItem)
   at ApiCheck.Comparer.TypeComparer.AddMethodsToPairList(Action`1 addToPairList, Func`1 getMethods)
   at ApiCheck.Comparer.TypeComparer.CompareMethods(Func`2 getMethods, Func`4 getMethod, ResultContext resultContext)
   at ApiCheck.Comparer.TypeComparer.Compare()
   at ApiCheck.Comparer.AssemblyComparer.CompareTypes()
   at ApiCheck.Comparer.AssemblyComparer.Compare()
   at ApiCheck.ApiComparer.CheckApi()
```