### PR TITLE
Comparing a changed parameter with default value null failed.

### DIFF
--- a/ApiCheck.Test/Comparer/ParameterComparerTest.cs
+++ b/ApiCheck.Test/Comparer/ParameterComparerTest.cs
@@ -31,6 +31,16 @@ namespace ApiCheck.Test.Comparer
     }
 
     [Test]
+    public void When_default_flag_null_changed_should_report()
+    {
+      Assembly assembly1 = ApiBuilder.CreateApi().Class().Method().DefaultParameter(typeof(object), null).Build().Build().Build();
+      Assembly assembly2 = ApiBuilder.CreateApi().Class().Method().Parameter(typeof(object)).Build().Build().Build();
+      Mock<IComparerResult> sut = new Builder(assembly1, assembly2).ComparerResultMock;
+
+      sut.Verify(result => result.AddChangedProperty("Default Value", "null", "", Severity.Error), Times.Once);
+    }
+
+    [Test]
     public void When_name_changed_should_report()
     {
       Assembly assembly1 = ApiBuilder.CreateApi().Class().Method().Parameter(typeof(int), "myParam1").Build().Build().Build();

--- a/ApiCheck/Comparer/ParameterComparer.cs
+++ b/ApiCheck/Comparer/ParameterComparer.cs
@@ -25,7 +25,7 @@ namespace ApiCheck.Comparer
     {
       if (!Equals(ReferenceType.RawDefaultValue, NewType.RawDefaultValue))
       {
-        ComparerResult.AddChangedProperty("Default Value", ReferenceType.RawDefaultValue.ToString(), NewType.RawDefaultValue.ToString(), Severity.Error);
+        ComparerResult.AddChangedProperty("Default Value", (ReferenceType.RawDefaultValue ?? "null").ToString(), (NewType.RawDefaultValue ?? "null").ToString(), Severity.Error);
       }
     }
 


### PR DESCRIPTION
Fix for a failing comparison in the following scenario.

From:
```
public void Foo(object x = null) {}
```
To:
```
public void Foo(object x) {}
```