### PR TITLE
Parameter comparison always fails on an array of generics

### DIFF
--- a/ApiCheck/Utility/TypeExtensions.cs
+++ b/ApiCheck/Utility/TypeExtensions.cs
@@ -48,6 +48,10 @@ namespace ApiCheck.Utility
       {
         return string.Format("{0}.{1}<{2}>", type.Namespace, type.Name, string.Join(",", type.GetGenericArguments().Select(t => t.GetCompareableName())));
       }
+      if (type.IsArray)
+      {
+        return string.Format("{0}.{1}[{2}]", type.Namespace, type.Name, GetCompareableName(type.GetElementType()));
+      }
       return type.FullName;
     }
   }


### PR DESCRIPTION
`typeof(Action<string>[]).GetCompareableName()`

Resulted in;

```System.Action`1[[System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]][]```