### PR TITLE
Types should ignore interface removal when the interface is on the ignore list

### DIFF
--- a/ApiCheck.Test/Comparer/ComparerContextTest.cs
+++ b/ApiCheck.Test/Comparer/ComparerContextTest.cs
@@ -1,4 +1,5 @@
-﻿using ApiCheck.Comparer;
+﻿using System;
+using ApiCheck.Comparer;
 using ApiCheck.Result;
 using ApiCheck.Test.Builder;
 using NUnit.Framework;
@@ -18,6 +19,17 @@ namespace ApiCheck.Test.Comparer
       IComparerResult sut = new Builder(assembly1, assembly2, new[] { "A.C" }).Build();
 
       Assert.AreEqual(0, sut.RemovedItems.Count());
+    }
+
+    [Test]
+    public void When_interface_extension_is_removed_and_ignored_should_not_report()
+    {
+      Assembly assembly1 = ApiBuilder.CreateApi().Interface(interfaces: new[] { typeof(IDisposable) }).Build().Build();
+      Assembly assembly2 = ApiBuilder.CreateApi().Interface().Build().Build();
+      var sut = new Builder(assembly1, assembly2, new[] { "System.IDisposable" }).Build();
+
+      Assert.AreEqual(0, sut.ComparerResults.First().RemovedItems.Count());
+      Assert.AreEqual(0, sut.ComparerResults.First().AddedItems.Count());
     }
 
     [Test]

--- a/ApiCheck/Comparer/TypeComparer.cs
+++ b/ApiCheck/Comparer/TypeComparer.cs
@@ -119,8 +119,8 @@ namespace ApiCheck.Comparer
 
     private void CompareInterfaces()
     {
-      IEnumerable<string> referenceInterfaces = ReferenceType.GetInterfaces().Select(@interface => @interface.GetCompareableName()).ToList();
-      IEnumerable<string> newInterfaces = NewType.GetInterfaces().Select(@interface => @interface.GetCompareableName()).ToList();
+      IEnumerable<string> referenceInterfaces = GetInterfaces(ReferenceType).ToList();
+      IEnumerable<string> newInterfaces = GetInterfaces(NewType).ToList();
 
       // missing interfaces
       foreach (string @interface in referenceInterfaces.Except(newInterfaces))
@@ -133,6 +133,11 @@ namespace ApiCheck.Comparer
       {
         ComparerResult.AddAddedItem(ResultContext.Interface, @interface, Severity.Warning);
       }
+    }
+
+    private IEnumerable<string> GetInterfaces(TypeInfo typeInfo)
+    {
+      return typeInfo.GetInterfaces().Where(@interface => ComparerContext.IsNotIgnored(@interface.GetTypeInfo())).Select(@interface => @interface.GetCompareableName());
     }
 
     private void CompareEvents()


### PR DESCRIPTION
In case of an interface removal that should be ignored, we currently need to add the interface itself to the ignore list and all of the types/interfaces that are implementing/extending it. This effectively causes all other changes on these types to be ignored as well. With this PR it is possible specifically ignore the interface removal. 

