### PR TITLE
Comparing methods with different generic parameters failed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,4 @@ UpgradeLog*.htm
 FakesAssemblies/
 
 .fake/
+.vs/

--- a/ApiCheck.Test/Comparer/TypeComparerTest.cs
+++ b/ApiCheck.Test/Comparer/TypeComparerTest.cs
@@ -186,6 +186,16 @@ namespace ApiCheck.Test.Comparer
       sut.Verify(result => result.AddComparerResult(It.IsAny<IComparerResult>()), Times.AtLeastOnce);
     }
 
+    [Test]
+    public void When_defining_two_methods_with_different_generic_parameters_should_compare_without_exception()
+    {
+      Assembly assembly1 = ApiBuilder.CreateApi().Class().Method().GenericParameter().Build().Method().GenericParameter("B").Build().Build().Build();
+      Assembly assembly2 = ApiBuilder.CreateApi().Class().Method().GenericParameter().Build().Method().GenericParameter("B").Build().Build().Build();
+    
+      Mock<IComparerResult> sut;
+      Assert.DoesNotThrow(() => sut = new Builder(assembly1, assembly2).ComparerResultMock);
+    }
+
     private class Builder
     {
       private readonly Mock<IComparerResult> _comparerResultMock;

--- a/ApiCheck/Utility/TypeExtensions.cs
+++ b/ApiCheck/Utility/TypeExtensions.cs
@@ -52,7 +52,7 @@ namespace ApiCheck.Utility
       {
         return string.Format("{0}.{1}[{2}]", type.Namespace, type.Name, GetCompareableName(type.GetElementType()));
       }
-      return type.FullName;
+      return type.FullName ?? type.Name;
     }
   }
 }


### PR DESCRIPTION
Fixes the following scenario:

	interface IFoo<A, B>
	{
	    void Bar(IList<A> list);
	    void Bar(IList<B> list);
	}