### PR TITLE
Update default value and field comparer

### DIFF
--- a/ApiCheck/Comparer/FieldComparer.cs
+++ b/ApiCheck/Comparer/FieldComparer.cs
@@ -28,7 +28,9 @@ namespace ApiCheck.Comparer
         // compare numeric enum values
         object referenceValue = ReferenceType.GetRawConstantValue();
         object newValue = NewType.GetRawConstantValue();
-        if (Convert.ToInt32(referenceValue) != Convert.ToInt32(newValue))
+        Type enumBaseType = ReferenceType.FieldType.GetEnumUnderlyingType();
+
+        if (!Convert.ChangeType(referenceValue, enumBaseType).Equals(Convert.ChangeType(newValue, enumBaseType)))
         {
           ComparerResult.AddChangedProperty("Value", referenceValue.ToString(), newValue.ToString(), Severities.ConstEnumValueChanged);
         }

--- a/ApiCheck/Comparer/ParameterComparer.cs
+++ b/ApiCheck/Comparer/ParameterComparer.cs
@@ -23,10 +23,26 @@ namespace ApiCheck.Comparer
 
     private void CompareDefaultValue()
     {
-      if (!Equals(ReferenceType.RawDefaultValue, NewType.RawDefaultValue))
+      if (!Equals(GetDefaultValue(ReferenceType), GetDefaultValue(NewType)))
       {
         ComparerResult.AddChangedProperty("Default Value", (ReferenceType.RawDefaultValue ?? "null").ToString(), (NewType.RawDefaultValue ?? "null").ToString(), Severities.DefaultValueChanged);
       }
+    }
+
+    private object GetDefaultValue(ParameterInfo parameter)
+    {
+
+      if (parameter.ParameterType == typeof(DateTime) && (parameter.Attributes & ParameterAttributes.HasDefault) != ParameterAttributes.None)
+      {
+        return DateTime.MinValue;
+      }
+
+      if (parameter.ParameterType == typeof(Guid) && (parameter.Attributes & ParameterAttributes.HasDefault) != ParameterAttributes.None)
+      {
+        return Guid.Empty;
+      }
+
+      return parameter.RawDefaultValue;
     }
 
     private void CompareName()

--- a/ApiCheck/Comparer/ParameterComparer.cs
+++ b/ApiCheck/Comparer/ParameterComparer.cs
@@ -32,12 +32,12 @@ namespace ApiCheck.Comparer
     private object GetDefaultValue(ParameterInfo parameter)
     {
 
-      if (parameter.ParameterType == typeof(DateTime) && (parameter.Attributes & ParameterAttributes.HasDefault) != ParameterAttributes.None)
+      if (parameter.ParameterType == typeof(DateTime) && parameter.Attributes.HasFlag(ParameterAttributes.HasDefault))
       {
         return DateTime.MinValue;
       }
 
-      if (parameter.ParameterType == typeof(Guid) && (parameter.Attributes & ParameterAttributes.HasDefault) != ParameterAttributes.None)
+      if (parameter.ParameterType == typeof(Guid) && parameter.Attributes.HasFlag(ParameterAttributes.HasDefault))
       {
         return Guid.Empty;
       }


### PR DESCRIPTION
This PR should fix issue #24.

##### Description:
Handling default value comparing for System.DateTime and System.Guid
Handling different Enum underlaying types (e.g. enum:long or enum:uint)

@PMudra:  I was **not** able to get the test projects running under VS2022. So, the changes are currently only tested while executing ApiCheck.