### PR TITLE
Update YamlDotNet dependency

### DIFF
--- a/ApiCheck.Test/ApiCheck.Test.csproj
+++ b/ApiCheck.Test/ApiCheck.Test.csproj
@@ -41,7 +41,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.2.1" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <PackageReference Include="Moq" Version="4.18.3" />
   </ItemGroup>
 </Project>

--- a/ApiCheck/ApiCheck.csproj
+++ b/ApiCheck/ApiCheck.csproj
@@ -33,6 +33,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Reflection.MetadataLoadContext" Version="6.0.0" />
-    <PackageReference Include="YamlDotNet.Signed" Version="4.2.1" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 </Project>

--- a/ApiCheck/Loader/ConfigurationLoader.cs
+++ b/ApiCheck/Loader/ConfigurationLoader.cs
@@ -16,8 +16,8 @@ namespace ApiCheck.Loader
 
       using (var reader = new StreamReader(stream))
       {
-        Deserializer deserializer = new DeserializerBuilder()
-          .WithNamingConvention(new CamelCaseNamingConvention())
+        IDeserializer deserializer = new DeserializerBuilder()
+          .WithNamingConvention(CamelCaseNamingConvention.Instance)
           .Build();
 
         ComparerConfiguration configuration = deserializer.Deserialize<ComparerConfiguration>(reader);

--- a/build.fsx
+++ b/build.fsx
@@ -37,7 +37,7 @@ let tags = "ApiCheck Assembly Comparer NUnit Different Version Build Integration
 let globalDescription = "Library comparing different versions of an api using reflection to ensure compatibility with third party components."
 
 let packages =
-    [ "ApiCheck", globalDescription, ["YamlDotNet.Signed", "4.2.1"]
+    [ "ApiCheck", globalDescription, ["YamlDotNet", "16.3.0"]
       "ApiCheck.Console", globalDescription + " Console application.", []
       "ApiCheck.NUnit", globalDescription + " NUnit integration.", ["ApiCheck", version; "NUnit", "3.13.3"] ]
 


### PR DESCRIPTION
YamlDotNet.Signed was deprecated. That's why it was replaced by the current version of YamlDotNet. This fixes #29.